### PR TITLE
More helpful helpers

### DIFF
--- a/app/helpers/color_guard/helper.rb
+++ b/app/helpers/color_guard/helper.rb
@@ -1,5 +1,7 @@
 module ColorGuard::Helper
   def feature_active?(feature, user = nil)
+    user = current_user if user.nil? && defined?(:current_user)
+
     ColorGuard.active?(feature, user)
   end
 end

--- a/lib/color_guard.rb
+++ b/lib/color_guard.rb
@@ -20,7 +20,7 @@ module ColorGuard
     def rollout
       $rollout ||= begin
         raise "ColorGuard.store must be set" if store.nil?
-        Rollout.new(store)
+        Rollout.new(store, randomize_percentage: true)
       end
     end
   end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -4,7 +4,15 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper ColorGuard::Helper
+  helper_method :current_user
 
   def index
   end
+
+  private
+
+  def current_user
+    params[:user_id].to_i
+  end
+
 end

--- a/spec/dummy/app/views/application/index.html.erb
+++ b/spec/dummy/app/views/application/index.html.erb
@@ -8,5 +8,5 @@
   <marquee behavior="scroll" direction="right">
     <%= image_tag "unicorn.gif" %>
   </marquee>
-  <% end %>
+<% end %>
   

--- a/spec/dummy/config/initializers/color_guard.rb
+++ b/spec/dummy/config/initializers/color_guard.rb
@@ -18,6 +18,14 @@ end
 
 ColorGuard.store = MemoryKeyStore.new
 
+ColorGuard.define_group(:evens) do |user|
+  user.id % 2 == 0
+end
+
+ColorGuard.define_group(:odds) do |user|
+  user.id % 2 == 1
+end
+
 # Since our features are stored in memory instead of in redis we need to add defaults.
 # Otherwise there would be no way to set values. We'll start with everything off
 [:rainbows, :unicorns, :bill_murray].each do |feature_name|

--- a/spec/dummy/config/initializers/color_guard.rb
+++ b/spec/dummy/config/initializers/color_guard.rb
@@ -18,16 +18,17 @@ end
 
 ColorGuard.store = MemoryKeyStore.new
 
-ColorGuard.define_group(:evens) do |user|
-  user.id % 2 == 0
+ColorGuard.define_group(:evens) do |user_id|
+  user_id % 2 == 0
 end
 
-ColorGuard.define_group(:odds) do |user|
-  user.id % 2 == 1
+ColorGuard.define_group(:odds) do |user_id|
+  user_id % 2 == 1
 end
 
 # Since our features are stored in memory instead of in redis we need to add defaults.
 # Otherwise there would be no way to set values. We'll start with everything off
 [:rainbows, :unicorns, :bill_murray].each do |feature_name|
   ColorGuard.deactivate(feature_name)
+  ColorGuard.activate_group(feature_name, :odds)
 end

--- a/spec/helpers/color_guard/helper_spec.rb
+++ b/spec/helpers/color_guard/helper_spec.rb
@@ -13,5 +13,18 @@ RSpec.describe ColorGuard::Helper do
       allow(ColorGuard).to receive(:active?).and_return(false)
       expect(subject.feature_active?(:anything_else, 97)).to eq(false)
     end
+
+    context "if #current_user is a defined method" do
+      before do
+        def subject.current_user
+          13317
+        end
+      end
+
+      it "passes the current user to ColorGuard#active?" do
+        expect(ColorGuard).to receive(:active?).with(:feature, 13317)
+        subject.feature_active?(:feature)
+      end
+    end
   end
 end


### PR DESCRIPTION
Make the `feature_active?` helper automatically add the current user to the check if there is a current user available.

Also randomize the percentage for rollout so which users have and do not have a feature turned on is less predictable