### PR TITLE
Fix color_guard dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,79 +3,34 @@ PATH
   specs:
     color_guard (0.0.1)
       connection_pool
+      rack
       redis
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.5)
-      actionview (= 4.2.5)
-      activesupport (= 4.2.5)
-      rack (~> 1.6)
-      rack-test (~> 0.6.2)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.5)
-      activesupport (= 4.2.5)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activesupport (4.2.5)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    builder (3.2.2)
     cane (2.6.2)
       parallel
     connection_pool (2.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    erubis (2.7.0)
-    i18n (0.7.0)
     json (1.8.3)
-    loofah (2.0.3)
-      nokogiri (>= 1.5.9)
-    mini_portile (0.6.2)
-    minitest (5.8.3)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
     parallel (1.6.1)
-    rack (1.6.4)
-    rack-test (0.6.3)
-      rack (>= 1.0)
-    rails-deprecated_sanitizer (1.0.3)
-      activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
-      activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
-      rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.2)
-      loofah (~> 2.0)
-    railties (4.2.5)
-      actionpack (= 4.2.5)
-      activesupport (= 4.2.5)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
-    rake (10.4.2)
+    rack (2.0.0.alpha)
+      json
+    rake (10.5.0)
     redis (3.2.2)
-    rspec-core (3.4.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.3)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.0)
+    rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-rails (3.4.0)
-      actionpack (>= 3.0, < 4.3)
-      activesupport (>= 3.0, < 4.3)
-      railties (>= 3.0, < 4.3)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     simplecov (0.10.0)
@@ -83,10 +38,6 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    thor (0.19.1)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -94,8 +45,9 @@ PLATFORMS
 DEPENDENCIES
   cane
   color_guard!
-  rspec-rails
+  rake
+  rspec
   simplecov
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/color_guard.gemspec
+++ b/color_guard.gemspec
@@ -18,8 +18,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redis"
   s.add_dependency "connection_pool"
+  s.add_dependency "rack"
 
   s.add_development_dependency "cane"
-  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "rake"
 end


### PR DESCRIPTION
The unused rspec-rails dependency added a BUNCH of stuff we don't need
and also hid that it wasn't declaring rack